### PR TITLE
3: Make executable with Github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Build and Release Windows Executable
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (for manual runs, e.g. v1.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build executable
+        shell: pwsh
+        run: .\build_exe.ps1
+
+      - name: Archive distributable folder
+        shell: pwsh
+        run: Compress-Archive -Path .\dist\StockTickerDashboard\* -DestinationPath .\StockTickerDashboard-windows.zip -Force
+
+      - name: Resolve release tag
+        id: resolve_tag
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            "tag=${{ github.event.inputs.tag }}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          } else {
+            "tag=${{ github.ref_name }}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          }
+
+      - name: Create or update GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.resolve_tag.outputs.tag }}
+          files: StockTickerDashboard-windows.zip
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 *.pyc
 data/session_state.json
 data/session_crash_*.json
+
+# PyInstaller/build artifacts
+build/
+dist/
+*.spec
+
+# Local build virtual environment
+.venv-build/

--- a/README.md
+++ b/README.md
@@ -119,8 +119,57 @@ python main.py
 
 - `http://127.0.0.1:8050/`
 
+## Build Windows executable (portable folder)
+
+This project includes a PowerShell build script for a Windows `onedir` bundle:
+
+```powershell
+.\build_exe.ps1
+```
+
+Build output:
+
+- Executable folder: `dist/StockTickerDashboard/`
+- Executable: `dist/StockTickerDashboard/StockTickerDashboard.exe`
+
+Run:
+
+```powershell
+.\dist\StockTickerDashboard\StockTickerDashboard.exe
+```
+
+Then open:
+
+- `http://127.0.0.1:8050/`
+
+Session persistence location for the executable build:
+
+- `dist/StockTickerDashboard/data/session_state.json`
+- Crash snapshots: `dist/StockTickerDashboard/data/session_crash_*.json`
+
+To run on another Windows computer, copy the entire `dist/StockTickerDashboard` folder and run `StockTickerDashboard.exe` there.
+
+## GitHub Actions release build
+
+This repo now supports automated Windows executable releases via GitHub Actions.
+
+- Workflow file: `.github/workflows/release.yml`
+- Trigger options:
+  - Push a tag that starts with `v` (example: `v1.0.0`)
+  - Manually run workflow (`workflow_dispatch`) and provide a tag
+- Output release asset:
+  - `StockTickerDashboard-windows.zip` (contents of `dist/StockTickerDashboard`)
+
+Tag example:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
 ## Notes / limitations
 
-- This is an in-memory demo: user portfolios and stock prices live in the Dash server process memory (`server.config`). They are **not** written to disk.
-- If you run multiple worker processes, each worker would have its own memory; use a single process for development, or add a shared database if you need production-scale persistence.
-- “Dividend” is part of the random action set, but the current implementation only applies effects for `Up` and `Down` (so `Dividend` does not change prices).
+- App state is kept in server memory during runtime (`server.config`) and saved to JSON on shutdown/updates.
+- For source runs (`python main.py`), session data is written under `data/session_state.json` in the project directory.
+- For executable runs, session data is written under the executable folder (`dist/StockTickerDashboard/data/session_state.json`).
+- If you run multiple worker processes, each worker has separate in-memory state; use a shared database for production-scale persistence.

--- a/build_exe.ps1
+++ b/build_exe.ps1
@@ -1,0 +1,60 @@
+param(
+    [string]$AppName = "StockTickerDashboard",
+    [string]$VenvDir = ".venv-build"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-VenvPython {
+    param([string]$Path)
+    if ($IsWindows -or $env:OS -eq "Windows_NT") {
+        return Join-Path $Path "Scripts/python.exe"
+    }
+    return Join-Path $Path "bin/python"
+}
+
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repoRoot
+
+$venvPython = Get-VenvPython -Path $VenvDir
+
+if (-not (Test-Path $venvPython)) {
+    Write-Host "Creating build virtual environment at $VenvDir ..."
+    py -3 -m venv $VenvDir
+}
+
+$venvPython = Get-VenvPython -Path $VenvDir
+
+Write-Host "Installing/upgrading build dependencies ..."
+& $venvPython -m pip install --upgrade pip
+& $venvPython -m pip install dash plotly pyinstaller
+
+Write-Host "Cleaning previous build output ..."
+if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
+if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
+if (Test-Path "$AppName.spec") { Remove-Item -Force "$AppName.spec" }
+
+Write-Host "Building executable with PyInstaller ..."
+& $venvPython -m PyInstaller `
+    --noconfirm `
+    --clean `
+    --name $AppName `
+    --onedir `
+    --add-data "assets;assets" `
+    --add-data "pages;pages" `
+    --add-data "callbacks;callbacks" `
+    main.py
+
+$distDir = Join-Path $repoRoot "dist\$AppName"
+$exePath = Join-Path $distDir "$AppName.exe"
+
+if (-not (Test-Path $exePath)) {
+    throw "Build finished but executable not found at $exePath"
+}
+
+Write-Host ""
+Write-Host "Build complete."
+Write-Host "Executable: $exePath"
+Write-Host "Run: .\dist\$AppName\$AppName.exe"
+Write-Host "Open in browser: http://127.0.0.1:8050"
+Write-Host "Session file location at runtime: .\dist\$AppName\data\session_state.json"

--- a/session_persistence.py
+++ b/session_persistence.py
@@ -12,7 +12,17 @@ from typing import Any
 
 from constants import commodities
 
-SESSION_PATH = Path(__file__).resolve().parent / "data" / "session_state.json"
+
+def _runtime_base_dir() -> Path:
+    """Return writable runtime base folder for session files."""
+    # PyInstaller/other frozen builds: keep data beside the executable.
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    # Source run: keep existing repo-local behavior.
+    return Path(__file__).resolve().parent
+
+
+SESSION_PATH = _runtime_base_dir() / "data" / "session_state.json"
 VERSION = 1
 
 _app_ref: Any = None


### PR DESCRIPTION
This repo now supports automated Windows executable releases via GitHub Actions.

- Workflow file: `.github/workflows/release.yml`
- Trigger options:
  - Push a tag that starts with `v` (example: `v1.0.0`)
  - Manually run workflow (`workflow_dispatch`) and provide a tag
- Output release asset:
  - `StockTickerDashboard-windows.zip` (contents of `dist/StockTickerDashboard`)
