### PR TITLE
26: Improve Concurrent Player Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Hydration runs when the user page loads (URL change or initial load). Buy/sell/a
 2. Install dependencies:
 
 ```bash
-pip install dash plotly
+pip install -r requirements.txt
 ```
 
-3. Start the server:
+3. Start the server (uses **Waitress**, a threaded WSGI server suitable for several phones on the same Wi‑Fi):
 
 ```bash
 python main.py
@@ -117,11 +117,22 @@ python main.py
 
 4. Open the app:
 
-- `http://127.0.0.1:8050/`
+- On the host machine: `http://127.0.0.1:8050/`
+- On other devices on the LAN: `http://<host-ip>:8050/` (same port; firewall must allow inbound TCP 8050).
+
+**Important:** Game state lives in **one Python process** (`server.config`). Use **one** server process only (do not run multiple `python main.py` or multiple copies of the executable expecting a shared game). For many concurrent clients, use **one** Waitress process with multiple **threads** (defaults are set in `constants.py`: `WAITRESS_THREADS`, `PRICE_POLL_INTERVAL_MS`).
+
+**Linux / macOS (alternative):** you can serve the same app with Gunicorn using a **single worker** and multiple threads, for example:
+
+```bash
+gunicorn -w 1 -k gthread --threads 16 -b 0.0.0.0:8050 main:server
+```
+
+(Requires `pip install gunicorn` and a `main:server` export — see `main.py`.)
 
 ## Build Windows executable (portable folder)
 
-This project includes a PowerShell build script for a Windows `onedir` bundle:
+This project includes a PowerShell build script for a Windows `onedir` bundle. The executable runs the same entry point as `python main.py` (Waitress on port 8050); PyInstaller bundles `waitress` from `requirements.txt`.
 
 ```powershell
 .\build_exe.ps1
@@ -138,9 +149,10 @@ Run:
 .\dist\StockTickerDashboard\StockTickerDashboard.exe
 ```
 
-Then open:
+Then open (same as a source run):
 
-- `http://127.0.0.1:8050/`
+- On the host: `http://127.0.0.1:8050/`
+- Other devices: `http://<host-ip>:8050/`
 
 Session persistence location for the executable build:
 
@@ -169,7 +181,7 @@ git push origin v1.0.0
 
 ## Notes / limitations
 
-- App state is kept in server memory during runtime (`server.config`) and saved to JSON on shutdown/updates.
+- App state is kept in server memory during runtime (`server.config`) and saved to JSON on shutdown and after trades (buy/sell/add cash writes are **debounced** briefly to reduce disk contention when many players trade at once).
 - For source runs (`python main.py`), session data is written under `data/session_state.json` in the project directory.
 - For executable runs, session data is written under the executable folder (`dist/StockTickerDashboard/data/session_state.json`).
-- If you run multiple worker processes, each worker has separate in-memory state; use a shared database for production-scale persistence.
+- If you run multiple **worker** processes (e.g. Gunicorn `workers > 1`), each worker has separate in-memory state; this app expects **one** process. Use a shared database if you ever shard workers.

--- a/build_exe.ps1
+++ b/build_exe.ps1
@@ -27,7 +27,8 @@ $venvPython = Get-VenvPython -Path $VenvDir
 
 Write-Host "Installing/upgrading build dependencies ..."
 & $venvPython -m pip install --upgrade pip
-& $venvPython -m pip install dash plotly pyinstaller
+& $venvPython -m pip install pyinstaller
+& $venvPython -m pip install -r requirements.txt
 
 Write-Host "Cleaning previous build output ..."
 if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
@@ -40,6 +41,7 @@ Write-Host "Building executable with PyInstaller ..."
     --clean `
     --name $AppName `
     --onedir `
+    --hidden-import waitress `
     --add-data "assets;assets" `
     --add-data "pages;pages" `
     --add-data "callbacks;callbacks" `

--- a/callbacks/user_callbacks.py
+++ b/callbacks/user_callbacks.py
@@ -205,9 +205,9 @@ def handle_user_actions(
     all_users[user_key] = current_state
     net_value = _net_value(current_state["balance"], current_state["stocks"], stock_prices)
 
-    from session_persistence import save_session
+    from session_persistence import schedule_debounced_save
 
-    save_session(dash.get_app())
+    schedule_debounced_save(dash.get_app())
 
     return (
         _to_table_data(current_state["stocks"]),

--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,15 @@
-﻿commodities = ["Gold", "Silver", "Bonds", "Oil", "Industrials", "Grain"]
+commodities = ["Gold", "Silver", "Bonds", "Oil", "Industrials", "Grain"]
 user_starting_balance = 5000
+
+# Client poll interval for shared stock prices / game meta (ms). Higher values reduce
+# Dash HTTP load per phone on LAN parties (see main.py dcc.Interval).
+PRICE_POLL_INTERVAL_MS = 2500
+
+# Waitress WSGI thread pool size (single process; do not use multiple Waitress workers).
+WAITRESS_THREADS = 16
+
+# Delay before writing session after a trade burst (debounced disk save).
+SESSION_SAVE_DEBOUNCE_SEC = 0.75
 
 # Dashboard bar chart: one RGB color per commodity (Plotly rgb strings)
 COMMODITY_BAR_COLORS = {

--- a/main.py
+++ b/main.py
@@ -1,7 +1,13 @@
+import logging
+import socket
+
 from dash import Dash, dcc, html, page_container, callback, clientside_callback, Output, Input, dash
+from waitress import serve
+
 import callbacks.dashboard_callbacks
 import callbacks.user_callbacks  # noqa: F401 — register portfolio callbacks at startup
 from callbacks.user_callbacks import count_named_players
+import constants
 from session_persistence import load_session, register_shutdown_handlers
 
 app = Dash(
@@ -18,6 +24,8 @@ app = Dash(
 
 load_session(app)
 register_shutdown_handlers(app)
+
+server = app.server
 
 # Define layout — #dash-shell / #content flex chain works with assets/viewport_desktop.css
 app.layout = html.Div(
@@ -36,7 +44,11 @@ app.layout = html.Div(
             style={"display": "none"},
             multiple=False,
         ),
-        dcc.Interval(id="stock-prices-poll", interval=1000, n_intervals=0),
+        dcc.Interval(
+            id="stock-prices-poll",
+            interval=constants.PRICE_POLL_INTERVAL_MS,
+            n_intervals=0,
+        ),
         dcc.Store(id="plotly-resize-hook", data=0),
         html.Div(
             id="content",
@@ -138,7 +150,58 @@ clientside_callback(
 
 import callbacks.session_callbacks  # noqa: F401 — Save/Load session on landing page
 
+LISTEN_HOST = "0.0.0.0"
+LISTEN_PORT = 8050
+
+
+def _guess_lan_ipv4() -> str | None:
+    """Best-effort primary IPv4 for URLs other devices can use (same as outbound route)."""
+    try:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            probe.connect(("8.8.8.8", 80))
+            return probe.getsockname()[0]
+        finally:
+            probe.close()
+    except OSError:
+        pass
+    try:
+        host = socket.gethostname()
+        ip = socket.gethostbyname(host)
+        if ip and ip != "127.0.0.1":
+            return ip
+    except OSError:
+        pass
+    return None
+
+
+def _print_startup_banner() -> None:
+    local_url = f"http://127.0.0.1:{LISTEN_PORT}/"
+    print(f"\n  This PC:     {local_url}", flush=True)
+    lan = _guess_lan_ipv4()
+    if lan and lan != "127.0.0.1":
+        print(f"  Other devices: http://{lan}:{LISTEN_PORT}/", flush=True)
+    else:
+        print(
+            f"  Other devices: use this machine's IPv4 in Network settings, port {LISTEN_PORT} "
+            "(e.g. http://192.168.x.x:8050/)",
+            flush=True,
+        )
+    print("  Logs and errors (INFO and above) follow. Ctrl+C to stop.\n", flush=True)
+
+
 if __name__ == "__main__":
-    # use_reloader=False: Werkzeug's stat-reloader parent process never serves requests, so
-    # server.config stays empty; its atexit would overwrite session_state.json with defaults.
-    app.run(host="0.0.0.0", port=8050, debug=False, use_reloader=False)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+        force=True,
+    )
+    # Threaded Waitress WSGI: handles many concurrent Dash clients (LAN parties). Single process
+    # only — game state lives in server.config (see README). PyInstaller exe uses this block too.
+    _print_startup_banner()
+    serve(
+        server,
+        host=LISTEN_HOST,
+        port=LISTEN_PORT,
+        threads=constants.WAITRESS_THREADS,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+dash
+plotly
+waitress

--- a/session_persistence.py
+++ b/session_persistence.py
@@ -6,11 +6,12 @@ import json
 import os
 import signal
 import sys
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from constants import commodities
+from constants import SESSION_SAVE_DEBOUNCE_SEC, commodities
 
 
 def _runtime_base_dir() -> Path:
@@ -263,6 +264,39 @@ def save_session(app=None, server=None) -> None:
     _atomic_write_json(SESSION_PATH, payload)
 
 
+_debounce_lock = threading.Lock()
+_debounce_timer: threading.Timer | None = None
+
+
+def cancel_debounced_save() -> None:
+    """Cancel a pending debounced save (e.g. before shutdown flush)."""
+    global _debounce_timer
+    with _debounce_lock:
+        if _debounce_timer is not None:
+            _debounce_timer.cancel()
+            _debounce_timer = None
+
+
+def schedule_debounced_save(app, delay_sec: float | None = None) -> None:
+    """Coalesce rapid trade saves into one disk write after a short quiet period."""
+    global _debounce_timer
+    if delay_sec is None:
+        delay_sec = SESSION_SAVE_DEBOUNCE_SEC
+
+    def _run():
+        global _debounce_timer
+        with _debounce_lock:
+            _debounce_timer = None
+        save_session(app)
+
+    with _debounce_lock:
+        if _debounce_timer is not None:
+            _debounce_timer.cancel()
+        _debounce_timer = threading.Timer(delay_sec, _run)
+        _debounce_timer.daemon = True
+        _debounce_timer.start()
+
+
 def _crash_snapshot_path() -> Path:
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     return SESSION_PATH.parent / f"session_crash_{ts}.json"
@@ -329,6 +363,7 @@ def register_shutdown_handlers(app) -> None:
                 app = _app_ref
             if app is None:
                 return
+            cancel_debounced_save()
             server = app.server
             _sync_dashboard_module_prices_to_server(server)
             proposed = build_payload(server)


### PR DESCRIPTION
The app now runs under Waitress with multiple threads instead of Flask’s dev server, so many phones can hit the server at once without requests piling up. Price polling was slowed slightly and session file writes after trades were debounced to cut background HTTP traffic and disk contention during LAN play.