### PR TITLE
15: Implement market surge

### DIFF
--- a/callbacks/dashboard_callbacks.py
+++ b/callbacks/dashboard_callbacks.py
@@ -13,6 +13,12 @@ from dashboard_charts import (
     build_stock_graph_figure,
 )
 from domain.dice import roll_dice
+from domain.market_surge import (
+    ensure_market_surge_config,
+    maybe_bias_roll,
+    normalize_market_surge_enabled,
+    rotate_turn_state,
+)
 from domain.roll_effects import apply_roll_to_state
 from domain.timeline import timeline_for_figures, turn_baseline_stock_prices
 from domain.user_state import (
@@ -45,16 +51,19 @@ def _timeline_for_figures(server):
 def _apply_one_roll(stock, action, value):
     """Apply one dice outcome to live_prices, USER_STATE, and server.config; persist."""
     server = dash.get_app().server
+    action, value = maybe_bias_roll(server, stock, action, value)
     user_state = server.config.setdefault("USER_STATE", {})
     apply_roll_to_state(live_prices, user_state, stock, action, value)
     server.config["STOCK_PRICES"] = {
         c: round(float(live_prices.get(c, 1.00)), 2) for c in COMMODITIES
     }
     save_session(dash.get_app())
+    return action, value
 
 
 def _roll_once_outputs():
     stock, action, value = roll_dice()
+    action, value = _apply_one_roll(stock, action, value)
     value_str = str(int(round(value * 100)))
     server = dash.get_app().server
     rolls = server.config.setdefault("CURRENT_TURN_ROLLS", [])
@@ -62,7 +71,6 @@ def _roll_once_outputs():
         rolls = []
         server.config["CURRENT_TURN_ROLLS"] = rolls
     rolls.append({"commodity": stock, "action": action, "value": value_str})
-    _apply_one_roll(stock, action, value)
     fig = build_stock_graph_figure(live_prices)
     return dashboard_table_rows(live_prices, _turn_baseline_stock_prices(server)), fig
 
@@ -141,6 +149,7 @@ def _increment_turn_and_save():
         if isinstance(r, dict)
     ]
     server.config["CURRENT_TURN_ROLLS"] = []
+    rotate_turn_state(server)
     _append_turn_timeline_snapshot()
     server.config["TURN_COUNT"] = int(server.config.get("TURN_COUNT", 1)) + 1
     save_session(dash.get_app())
@@ -317,6 +326,7 @@ def _build_players_modal_list_children():
     Output("settings-modal", "style"),
     Output("turn-roll-sec-input", "value"),
     Output("game-max-turns-input", "value"),
+    Output("market-surge-checkbox", "value"),
     [
         Input("settings-gear-btn", "n_clicks"),
         Input("settings-modal-backdrop-btn", "n_clicks"),
@@ -328,6 +338,7 @@ def _build_players_modal_list_children():
     ],
     State("turn-roll-sec-input", "value"),
     State("game-max-turns-input", "value"),
+    State("market-surge-checkbox", "value"),
     prevent_initial_call=False,
 )
 def settings_modal_and_interval(
@@ -340,13 +351,14 @@ def settings_modal_and_interval(
     _initial_load,
     sec_input,
     max_turns_input,
+    market_surge_value,
 ):
     """Modal only. Do not Output turn-roll-interval.interval here — that resets the timer in Dash 3 and drops ticks."""
     ctx = dash.callback_context
     server = dash.get_app().server
     # Dashboard-only layout: never patch these outputs or set_props from other routes (breaks Dash 3 renderer).
     if not _pathname_is_dashboard(pathname):
-        return no_update, no_update, no_update
+        return no_update, no_update, no_update, no_update
 
     hid, vis = _HIDDEN_SETTINGS_MODAL_STYLE, _VISIBLE_SETTINGS_MODAL_STYLE
 
@@ -356,34 +368,42 @@ def settings_modal_and_interval(
     def max_turns_from_server() -> int:
         return _normalize_game_max_turns(server.config.get("GAME_MAX_TURNS"))
 
+    def market_surge_from_server() -> list[str]:
+        enabled = normalize_market_surge_enabled(server.config.get("MARKET_SURGE_ENABLED"))
+        return ["enabled"] if enabled else []
+
     trig = ctx.triggered_id
     if trig is None:
-        return hid, no_update, no_update
+        return hid, no_update, no_update, no_update
 
     if trig == "url":
-        return no_update, no_update, no_update
+        return no_update, no_update, no_update, no_update
 
     if trig in ("session-reload", "_initial_load"):
-        return no_update, no_update, no_update
+        ensure_market_surge_config(server)
+        return no_update, no_update, no_update, no_update
 
     if trig == "settings-gear-btn":
         s = sec_from_server()
         m = max_turns_from_server()
-        return vis, s, m
+        surge = market_surge_from_server()
+        return vis, s, m, surge
 
     if trig in ("settings-modal-backdrop-btn", "settings-modal-close-btn"):
-        return hid, no_update, no_update
+        return hid, no_update, no_update, no_update
 
     if trig == "settings-apply-btn":
         sec = _normalize_turn_roll_interval_sec(sec_input)
         max_t = _normalize_game_max_turns(max_turns_input)
+        surge_enabled = isinstance(market_surge_value, list) and "enabled" in market_surge_value
         server.config["TURN_ROLL_INTERVAL_SEC"] = sec
         server.config["GAME_MAX_TURNS"] = max_t
+        server.config["MARKET_SURGE_ENABLED"] = surge_enabled
         save_session(dash.get_app())
         set_props("turn-roll-interval", {"interval": sec * 1000})
-        return hid, sec, max_t
+        return hid, sec, max_t, (["enabled"] if surge_enabled else [])
 
-    return no_update, no_update, no_update
+    return no_update, no_update, no_update, no_update
 
 
 @callback(

--- a/callbacks/user_callbacks.py
+++ b/callbacks/user_callbacks.py
@@ -5,6 +5,7 @@ from dash import Input, Output, State, no_update
 
 from callbacks.app_ref import callback
 from constants import COMMODITIES
+from domain.market_surge import record_trade
 from domain.user_state import (
     ANONYMOUS_USER_KEY,
     default_user_state,
@@ -166,10 +167,12 @@ def handle_user_actions(
             if transaction_type == "buy" and current_state["balance"] >= cost:
                 current_state["stocks"][stock] += amount
                 current_state["balance"] = round(current_state["balance"] - cost, 2)
+                record_trade(dash.get_app().server, user_key, stock, amount)
                 message = f"Bought {amount} shares of {stock} for ${cost:.2f}"
             elif transaction_type == "sell" and current_state["stocks"][stock] >= amount:
                 current_state["stocks"][stock] -= amount
                 current_state["balance"] = round(current_state["balance"] + cost, 2)
+                record_trade(dash.get_app().server, user_key, stock, -amount)
                 message = f"Sold {amount} shares of {stock} for ${cost:.2f}"
 
     all_users[user_key] = current_state

--- a/components/dashboard_modals.py
+++ b/components/dashboard_modals.py
@@ -172,6 +172,23 @@ def build_settings_modal():
                     ),
                     html.Div(
                         [
+                            dcc.Checklist(
+                                id="market-surge-checkbox",
+                                options=[{"label": "Market Surge", "value": "enabled"}],
+                                value=[],
+                                inputStyle={"marginRight": "8px"},
+                                labelStyle={
+                                    "fontWeight": "600",
+                                    "fontSize": "clamp(0.95rem, 2vw, 1.05rem)",
+                                    "color": "#1a1a1a",
+                                    "cursor": "pointer",
+                                },
+                                style={"marginBottom": "22px"},
+                            ),
+                        ]
+                    ),
+                    html.Div(
+                        [
                             html.Button(
                                 "Apply",
                                 id="settings-apply-btn",

--- a/domain/market_surge.py
+++ b/domain/market_surge.py
@@ -3,6 +3,17 @@ import random
 from constants import COMMODITIES
 from domain.user_state import ANONYMOUS_USER_KEY
 
+"""
+directionBias: strength * 45%
+20Bias: strength * 75%
+
+strength: 0-1: net flow (buy - sell) and amount of players joined in
+	trade pressure x player participation
+	(net buy/sell)/(max(5000,total stock in play) x (players trading in stock)/(max(3,total players))
+
+
+"""
+
 MIN_UNITS_FOR_FULL_STRENGTH = 5000
 # Participation uses this floor for small games; for larger games we use total named players.
 MIN_PLAYERS_PARTICIPATION_DENOMINATOR = 3

--- a/domain/market_surge.py
+++ b/domain/market_surge.py
@@ -1,0 +1,221 @@
+import random
+
+from constants import COMMODITIES
+from domain.user_state import ANONYMOUS_USER_KEY
+
+MIN_UNITS_FOR_FULL_STRENGTH = 5000
+# Participation uses this floor for small games; for larger games we use total named players.
+MIN_PLAYERS_PARTICIPATION_DENOMINATOR = 3
+MAX_DIRECTION_BIAS = 0.75
+MAX_VALUE_20_BIAS = 0.75
+
+ROLL_VALUES = (0.05, 0.10, 0.20)
+
+
+def empty_flow_map() -> dict[str, int]:
+    return {commodity: 0 for commodity in COMMODITIES}
+
+
+def empty_participants_map() -> dict[str, list[str]]:
+    return {commodity: [] for commodity in COMMODITIES}
+
+
+def empty_participant_count_map() -> dict[str, int]:
+    return {commodity: 0 for commodity in COMMODITIES}
+
+
+def normalize_market_surge_enabled(raw) -> bool:
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(raw, (int, float)):
+        return bool(raw)
+    return False
+
+
+def normalize_flow_map(raw) -> dict[str, int]:
+    out = empty_flow_map()
+    if not isinstance(raw, dict):
+        return out
+    for commodity in COMMODITIES:
+        try:
+            out[commodity] = int(raw.get(commodity, 0))
+        except (TypeError, ValueError):
+            out[commodity] = 0
+    return out
+
+
+def normalize_participants_map(raw) -> dict[str, list[str]]:
+    out = empty_participants_map()
+    if not isinstance(raw, dict):
+        return out
+    for commodity in COMMODITIES:
+        users = raw.get(commodity, [])
+        if not isinstance(users, list):
+            continue
+        seen = set()
+        normalized = []
+        for user in users:
+            if not isinstance(user, str):
+                continue
+            name = user.strip()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            normalized.append(name)
+        out[commodity] = normalized
+    return out
+
+
+def normalize_participant_count_map(raw) -> dict[str, int]:
+    out = empty_participant_count_map()
+    if not isinstance(raw, dict):
+        return out
+    for commodity in COMMODITIES:
+        try:
+            out[commodity] = max(0, int(raw.get(commodity, 0)))
+        except (TypeError, ValueError):
+            out[commodity] = 0
+    return out
+
+
+def ensure_market_surge_config(server) -> None:
+    cfg = server.config
+    cfg["MARKET_SURGE_ENABLED"] = normalize_market_surge_enabled(
+        cfg.get("MARKET_SURGE_ENABLED")
+    )
+    cfg["TURN_NET_FLOW"] = normalize_flow_map(cfg.get("TURN_NET_FLOW"))
+    cfg["NEXT_TURN_SURGE_FLOW"] = normalize_flow_map(cfg.get("NEXT_TURN_SURGE_FLOW"))
+    cfg["TURN_STOCK_PARTICIPANTS"] = normalize_participants_map(
+        cfg.get("TURN_STOCK_PARTICIPANTS")
+    )
+    cfg["NEXT_TURN_SURGE_PARTICIPANT_COUNT"] = normalize_participant_count_map(
+        cfg.get("NEXT_TURN_SURGE_PARTICIPANT_COUNT")
+    )
+
+
+def record_trade(server, username: str, stock: str, signed_amount: int) -> None:
+    if stock not in COMMODITIES or signed_amount == 0:
+        return
+    ensure_market_surge_config(server)
+    flow_map = normalize_flow_map(server.config.get("TURN_NET_FLOW"))
+    flow_map[stock] += int(signed_amount)
+    server.config["TURN_NET_FLOW"] = flow_map
+
+    if not username or username == ANONYMOUS_USER_KEY:
+        return
+    participants = normalize_participants_map(server.config.get("TURN_STOCK_PARTICIPANTS"))
+    if username not in participants[stock]:
+        participants[stock].append(username)
+    server.config["TURN_STOCK_PARTICIPANTS"] = participants
+
+
+def rotate_turn_state(server) -> None:
+    ensure_market_surge_config(server)
+    flow_map = normalize_flow_map(server.config.get("TURN_NET_FLOW"))
+    participants = normalize_participants_map(server.config.get("TURN_STOCK_PARTICIPANTS"))
+    server.config["NEXT_TURN_SURGE_FLOW"] = flow_map
+    server.config["NEXT_TURN_SURGE_PARTICIPANT_COUNT"] = {
+        commodity: len(participants.get(commodity, [])) for commodity in COMMODITIES
+    }
+    server.config["TURN_NET_FLOW"] = empty_flow_map()
+    server.config["TURN_STOCK_PARTICIPANTS"] = empty_participants_map()
+
+
+def _named_player_count(user_state) -> int:
+    if not isinstance(user_state, dict):
+        return 0
+    count = 0
+    for username, state in user_state.items():
+        if username == ANONYMOUS_USER_KEY or not isinstance(state, dict):
+            continue
+        count += 1
+    return count
+
+
+def _stock_units_in_play(user_state, stock: str) -> int:
+    if stock not in COMMODITIES or not isinstance(user_state, dict):
+        return 0
+    total_units = 0
+    for username, state in user_state.items():
+        if username == ANONYMOUS_USER_KEY or not isinstance(state, dict):
+            continue
+        stocks = state.get("stocks")
+        if not isinstance(stocks, dict):
+            continue
+        try:
+            total_units += max(0, int(stocks.get(stock, 0)))
+        except (TypeError, ValueError):
+            continue
+    return total_units
+
+
+def _surge_strength(
+    net_flow: int, participant_count: int, total_players: int, units_for_full_strength: int
+) -> float:
+    denominator_units = max(int(units_for_full_strength), MIN_UNITS_FOR_FULL_STRENGTH)
+    base_strength = min(abs(int(net_flow)) / float(denominator_units), 1.0)
+    denominator = (
+        int(total_players)
+        if int(total_players) > MIN_PLAYERS_PARTICIPATION_DENOMINATOR
+        else MIN_PLAYERS_PARTICIPATION_DENOMINATOR
+    )
+    participation_factor = min(max(int(participant_count), 0) / float(denominator), 1.0)
+    return base_strength * participation_factor
+
+
+def _normalize_roll_value(value: float) -> float:
+    # Keep roll outcomes constrained to game-supported values only.
+    return min(ROLL_VALUES, key=lambda x: abs(float(value) - x))
+
+
+def _biased_roll_value(value: float, strength: float, aligned: bool) -> float:
+    current = _normalize_roll_value(value)
+    if not aligned or strength <= 0:
+        return current
+    if random.random() < (strength * MAX_VALUE_20_BIAS):
+        return 0.20
+    if current == 0.05 and random.random() < (strength * 0.35):
+        return 0.10
+    return current
+
+
+def maybe_bias_roll(server, stock: str, action: str, value: float) -> tuple[str, float]:
+    ensure_market_surge_config(server)
+    if not server.config.get("MARKET_SURGE_ENABLED", False):
+        return action, value
+    if action not in ("Up", "Down"):
+        return action, value
+
+    flow_map = normalize_flow_map(server.config.get("NEXT_TURN_SURGE_FLOW"))
+    participant_counts = normalize_participant_count_map(
+        server.config.get("NEXT_TURN_SURGE_PARTICIPANT_COUNT")
+    )
+    net_flow = int(flow_map.get(stock, 0))
+    if net_flow == 0:
+        return action, value
+
+    aligned_action = "Up" if net_flow > 0 else "Down"
+    user_state = server.config.get("USER_STATE")
+    total_players = _named_player_count(user_state)
+    units_for_full_strength = _stock_units_in_play(user_state, stock)
+    strength = _surge_strength(
+        net_flow,
+        participant_counts.get(stock, 0),
+        total_players,
+        units_for_full_strength,
+    )
+    if strength <= 0:
+        return action, value
+
+    resolved_action = action
+    if action != aligned_action and random.random() < (strength * MAX_DIRECTION_BIAS):
+        resolved_action = aligned_action
+
+    resolved_value = _biased_roll_value(
+        value,
+        strength,
+        aligned=(resolved_action == aligned_action),
+    )
+    return resolved_action, resolved_value

--- a/session_persistence.py
+++ b/session_persistence.py
@@ -12,6 +12,15 @@ from pathlib import Path
 from typing import Any
 
 from constants import COMMODITIES, DEFAULT_GAME_MAX_TURNS, SESSION_SAVE_DEBOUNCE_SEC
+from domain.market_surge import (
+    empty_flow_map,
+    empty_participant_count_map,
+    empty_participants_map,
+    normalize_flow_map,
+    normalize_market_surge_enabled,
+    normalize_participant_count_map,
+    normalize_participants_map,
+)
 from domain.user_state import normalize_user_state
 from runtime.live_stock_prices import live_prices, replace_live_prices
 
@@ -31,7 +40,8 @@ SESSION_PATH = _runtime_base_dir() / "data" / "session_state.json"
 # v4: optional turn_roll_interval_sec (integer seconds between dice rolls in a turn).
 # v5: optional current_turn_rolls / last_turn_rolls (dice feed; list of {commodity, action, value}).
 # v6: optional game_max_turns (end play when TURN_COUNT exceeds this).
-VERSION = 6
+# v7: optional market surge settings and per-turn surge state maps.
+VERSION = 7
 
 _app_ref: Any = None
 
@@ -230,6 +240,17 @@ def build_payload(server) -> dict[str, Any]:
     last_turn_rolls = _normalize_turn_roll_feed_list(server.config.get("LAST_TURN_ROLLS"))
 
     game_max_turns = _normalize_game_max_turns(server.config.get("GAME_MAX_TURNS"))
+    market_surge_enabled = normalize_market_surge_enabled(
+        server.config.get("MARKET_SURGE_ENABLED")
+    )
+    turn_net_flow = normalize_flow_map(server.config.get("TURN_NET_FLOW"))
+    turn_stock_participants = normalize_participants_map(
+        server.config.get("TURN_STOCK_PARTICIPANTS")
+    )
+    next_turn_surge_flow = normalize_flow_map(server.config.get("NEXT_TURN_SURGE_FLOW"))
+    next_turn_surge_participant_count = normalize_participant_count_map(
+        server.config.get("NEXT_TURN_SURGE_PARTICIPANT_COUNT")
+    )
 
     return {
         "version": VERSION,
@@ -241,6 +262,11 @@ def build_payload(server) -> dict[str, Any]:
         "current_turn_rolls": current_turn_rolls,
         "last_turn_rolls": last_turn_rolls,
         "game_max_turns": game_max_turns,
+        "market_surge_enabled": market_surge_enabled,
+        "turn_net_flow": turn_net_flow,
+        "turn_stock_participants": turn_stock_participants,
+        "next_turn_surge_flow": next_turn_surge_flow,
+        "next_turn_surge_participant_count": next_turn_surge_participant_count,
     }
 
 
@@ -271,6 +297,11 @@ def apply_payload_to_server(server, data: Any) -> None:
         server.config["CURRENT_TURN_ROLLS"] = []
         server.config["LAST_TURN_ROLLS"] = []
         server.config["GAME_MAX_TURNS"] = _normalize_game_max_turns(None)
+        server.config["MARKET_SURGE_ENABLED"] = normalize_market_surge_enabled(None)
+        server.config["TURN_NET_FLOW"] = empty_flow_map()
+        server.config["TURN_STOCK_PARTICIPANTS"] = empty_participants_map()
+        server.config["NEXT_TURN_SURGE_FLOW"] = empty_flow_map()
+        server.config["NEXT_TURN_SURGE_PARTICIPANT_COUNT"] = empty_participant_count_map()
         _sync_live_prices_from_dict(server.config["STOCK_PRICES"])
         return
 
@@ -286,6 +317,17 @@ def apply_payload_to_server(server, data: Any) -> None:
     )
     server.config["LAST_TURN_ROLLS"] = _normalize_turn_roll_feed_list(data.get("last_turn_rolls"))
     server.config["GAME_MAX_TURNS"] = _normalize_game_max_turns(data.get("game_max_turns"))
+    server.config["MARKET_SURGE_ENABLED"] = normalize_market_surge_enabled(
+        data.get("market_surge_enabled")
+    )
+    server.config["TURN_NET_FLOW"] = normalize_flow_map(data.get("turn_net_flow"))
+    server.config["TURN_STOCK_PARTICIPANTS"] = normalize_participants_map(
+        data.get("turn_stock_participants")
+    )
+    server.config["NEXT_TURN_SURGE_FLOW"] = normalize_flow_map(data.get("next_turn_surge_flow"))
+    server.config["NEXT_TURN_SURGE_PARTICIPANT_COUNT"] = normalize_participant_count_map(
+        data.get("next_turn_surge_participant_count")
+    )
     _sync_live_prices_from_dict(server.config["STOCK_PRICES"])
 
 
@@ -369,6 +411,13 @@ def load_session(app=None, server=None) -> None:
         server.config.setdefault("CURRENT_TURN_ROLLS", [])
         server.config.setdefault("LAST_TURN_ROLLS", [])
         server.config.setdefault("GAME_MAX_TURNS", _normalize_game_max_turns(None))
+        server.config.setdefault("MARKET_SURGE_ENABLED", normalize_market_surge_enabled(None))
+        server.config.setdefault("TURN_NET_FLOW", empty_flow_map())
+        server.config.setdefault("TURN_STOCK_PARTICIPANTS", empty_participants_map())
+        server.config.setdefault("NEXT_TURN_SURGE_FLOW", empty_flow_map())
+        server.config.setdefault(
+            "NEXT_TURN_SURGE_PARTICIPANT_COUNT", empty_participant_count_map()
+        )
         _sync_live_prices_from_dict(server.config["STOCK_PRICES"])
         return
 
@@ -386,6 +435,13 @@ def load_session(app=None, server=None) -> None:
         server.config.setdefault("CURRENT_TURN_ROLLS", [])
         server.config.setdefault("LAST_TURN_ROLLS", [])
         server.config.setdefault("GAME_MAX_TURNS", _normalize_game_max_turns(None))
+        server.config.setdefault("MARKET_SURGE_ENABLED", normalize_market_surge_enabled(None))
+        server.config.setdefault("TURN_NET_FLOW", empty_flow_map())
+        server.config.setdefault("TURN_STOCK_PARTICIPANTS", empty_participants_map())
+        server.config.setdefault("NEXT_TURN_SURGE_FLOW", empty_flow_map())
+        server.config.setdefault(
+            "NEXT_TURN_SURGE_PARTICIPANT_COUNT", empty_participant_count_map()
+        )
         _sync_live_prices_from_dict(server.config["STOCK_PRICES"])
         return
 


### PR DESCRIPTION
Added the market surge logic:

directionBias: strength * 75%
20Bias: strength * 75%

strength: 0-1: based on net flow (buy - sell) and amount of players joined in
	trade pressure x player participation
	(net buy/sell)/(max(5000,total stock in play) x (players trading in stock)/(max(3,total players))

