### PR TITLE
Add explicit imports

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -7,6 +7,15 @@ from callbacks.root_callbacks import register_root_callbacks
 from layout_root import build_root_layout
 from session_persistence import load_session, register_shutdown_handlers
 
+# PyInstaller misses some modules that Dash imports dynamically via `use_pages=True`.
+# Keep these explicit imports so frozen builds always include page dependencies.
+import components.dashboard_header  # noqa: F401
+import components.dashboard_main_row  # noqa: F401
+import components.dashboard_modals  # noqa: F401
+import components.dashboard_play_section  # noqa: F401
+import components.dashboard_timeline_row  # noqa: F401
+import dashboard_charts  # noqa: F401
+
 
 def create_app() -> Dash:
     app = Dash(


### PR DESCRIPTION
Was getting this error:



Traceback (most recent call last):
  File "main.py", line 7, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "app_factory.py", line 45, in <module>
  File "app_factory.py", line 12, in create_app
  File "dash\dash.py", line 639, in __init__
  File "dash\dash.py", line 752, in init_app
  File "dash\dash.py", line 2550, in enable_pages
  File "dash\_pages.py", line 442, in _import_layouts_from_pages
  File "C:\Users\Alex Taylor\Downloads\StockTickerDashboard-windows\_internal\pages\dashboard.py", line 3, in <module>
    from components.dashboard_header import build_dashboard_header
ModuleNotFoundError: No module named 'components'
[PYI-17492:ERROR] Failed to execute script 'main' due to unhandled exception!